### PR TITLE
constant interpolation in mt_resample()

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -519,6 +519,8 @@ mt_align_start <- function(
 #' @param exact_last_timestamp logical indicating if the last timestamp should
 #'   always be appended (which is the case by default). If \code{FALSE}, the
 #'   last timestamp is only appended if it is a multiple of the step_size.
+#' @param method defaults to "linear" for linear interpolation, can be set to 
+#'   "constant" for constant interpolation. 
 #'
 #' @return A mousetrap data object (see \link{mt_example}) with an additional
 #'   array (by default called \code{rs_trajectories}) containing the resampled
@@ -542,7 +544,7 @@ mt_resample <- function(data,
   use="trajectories", save_as="rs_trajectories",
   dimensions=c("xpos", "ypos"), timestamps="timestamps",
   step_size=10, exact_last_timestamp=TRUE,
-  verbose=FALSE, show_progress=NULL) {
+  verbose=FALSE, show_progress=NULL, method = "linear") {
 
   if(is.null(show_progress) == FALSE) {
     warning(
@@ -617,7 +619,7 @@ mt_resample <- function(data,
     # Perform linear interpolation for specified trajectory dimensions
     for (dimension in dimensions) {
       rs_trajectories[i,dimension,1:length(int_timestamps)] <- stats::approx(
-        current_timestamps, current_trajectories[dimension,], xout=custom_timesteps)$y
+        current_timestamps, current_trajectories[dimension,], xout=custom_timesteps, method = method)$y
     }
 
     if (verbose) {


### PR DESCRIPTION
For technical reasons it is possible that the mouse-coordinates are recorded whenever the mouse changes the position. In this case, it makes sense to do a constant interpolation of the coordinates. 
Thus, I propose an additional argument `method` within `mt_resample` that is passed to `approx()` and allows to use linear of constant interpolation. 

The following example code compares linear and constant interpolation: 

```javascript
library(mousetrap)

## linear interpolation 
ex <- mt_resample(mt_example, exact_last_timestamp = FALSE, 
                  save_as="rs_trajectories",
                  step_size=1L, method = "linear")
# ex$rs_trajectories[1, , 995:1010]


## constant interpolation 
ex_c <- mt_resample(mt_example, exact_last_timestamp = FALSE, 
                  save_as="rs_trajectories",
                  step_size=1L, method = "constant")
# ex_c$rs_trajectories[1, ,  995:1010]

plot(ex$rs_trajectories[1, "ypos" , 990:1010], type="b")
points(ex_c$rs_trajectories[1, "ypos" , 990:1010], col=2, pty=2, type="b")
```